### PR TITLE
Adding GetAuthUrlConfig to signIn function

### DIFF
--- a/lib/src/authenticate.tsx
+++ b/lib/src/authenticate.tsx
@@ -131,8 +131,8 @@ const AuthProvider: FunctionComponent = (
      * signIn()
      * ```
      */
-    const signIn = async (): Promise<void> => {
-        await AuthClient.getAuthorizationURL()
+    const signIn = async (config?: GetAuthURLConfig): Promise<void> => {
+        await AuthClient.getAuthorizationURL(config)
             .then((url) => {
                 Linking.openURL(url);
             })

--- a/lib/src/models.ts
+++ b/lib/src/models.ts
@@ -43,7 +43,7 @@ export interface AuthContextInterface {
     initialize: (config: AuthClientConfig) => Promise<void>;
     getDataLayer: () => Promise<DataLayer<any>>;
     getAuthorizationURL: (config?: GetAuthURLConfig) => Promise<string>;
-    signIn: () => Promise<void>;
+    signIn: (config?: GetAuthURLConfig) => Promise<void>;
     refreshAccessToken: () => Promise<TokenResponse>;
     getSignOutURL: () => Promise<string>;
     signOut: () => Promise<void>;


### PR DESCRIPTION
## Purpose
Current implementation doesn't allow user to pass Authorization URL Configs .

## Goals
Enable sending additional parameters with Authorization request.

## Approach
Add optional GetAuthURLConfig parameter to signIn function.
