### PR TITLE
Auth response error

### DIFF
--- a/lib/src/authenticate.tsx
+++ b/lib/src/authenticate.tsx
@@ -42,7 +42,8 @@ const initialState: AuthStateInterface = {
     isAuthenticated: false,
     refreshToken: "",
     scope: "",
-    tokenType: ""
+    tokenType: "",
+    authResponseError: {}
 };
 
 // Instantiate the auth client object.
@@ -510,6 +511,14 @@ const AuthProvider: FunctionComponent = (
                         );
                     }
                 }
+            } else if (url.parse(authUrl?.url)?.query.indexOf("error_description=") > -1) {
+                const dataList = url.parse(authUrl?.url)?.query.split("&");
+                const errorDescription = dataList[0].split("=")[1];
+                const errorCode = dataList[2].split("=")[1];
+                const errorMessage = errorDescription.split("+").join(" ");
+                
+                const error = { errorCode, errorMessage };
+                setState({ ...state, authResponseError: error });
             } else {
                 // TODO: Add logs when a logger is available.
                 // Tracked here https://github.com/asgardeo/asgardeo-auth-js-sdk/issues/151.
@@ -518,6 +527,13 @@ const AuthProvider: FunctionComponent = (
             // TODO: Add logs when a logger is available.
             // Tracked here https://github.com/asgardeo/asgardeo-auth-js-sdk/issues/151.
         }
+    };
+
+    /**
+     * This method clear the authentication response errors from state
+     */
+     const clearAuthResponseError = () : void => {
+        setState({ ...state, authResponseError: {} });
     };
 
     return (
@@ -540,7 +556,8 @@ const AuthProvider: FunctionComponent = (
                 signIn,
                 signOut,
                 state,
-                updateConfig
+                updateConfig,
+                clearAuthResponseError
             } }
         >
             { props.children }

--- a/lib/src/authenticate.tsx
+++ b/lib/src/authenticate.tsx
@@ -532,7 +532,7 @@ const AuthProvider: FunctionComponent = (
     /**
      * This method clear the authentication response errors from state
      */
-     const clearAuthResponseError = () : void => {
+    const clearAuthResponseError = () : void => {
         setState({ ...state, authResponseError: {} });
     };
 

--- a/lib/src/models.ts
+++ b/lib/src/models.ts
@@ -35,6 +35,7 @@ export interface AuthStateInterface {
     refreshToken: string;
     tokenType: string;
     isAuthenticated: boolean;
+    authResponseError?: {errorCode?: string, errorMessage?: string};
 }
 
 export interface AuthContextInterface {
@@ -56,6 +57,7 @@ export interface AuthContextInterface {
     isAuthenticated: () => Promise<boolean>;
     updateConfig: (config: Partial<AuthClientConfig>) => Promise<void>;
     requestCustomGrant: (config: CustomGrantConfig) => Promise<any>;
+    clearAuthResponseError: () => void;
 }
 
 export type AuthUrl = {


### PR DESCRIPTION
## Purpose
> The current implementation has no option to handle authenticating fail scenarios inside the SDK. When the fail() method gets executed in the adaptive script it redirects the user to the mobile application with an error and error description as follows.
>[No option to access error codes return from authentication fail scenario](https://github.com/asgardeo/asgardeo-react-native-oidc-sdk/issues/24)

## Approach
> Introduced a new variable  `authResponseError` to `AuthState` and introduced a new method `clearAuthResponseError` to clear the `authResponseError` from `AuthState`.

## Documentation
### clearAuthResponseError
`clearAuthResponseError: () => void;`

#### Description
This method clears the `authResponseError` from the `AuthState`.

#### Example
clearAuthResponseError();

#### Usage
```
import { useAuthContext} from '@asgardeo/auth-react-native';

const {
    state,
    clearAuthResponseError,
  } = useAuthContext();

  useEffect(() => {
    if (state.authResponseError?.hasOwnProperty('errorCode')) {
      setLoading(false);
      Alert.alert('Access Denied', state.authResponseError.errorMessage, [
        {
          text: 'OK',
          onPress: async () => {
            if (
              state.authResponseError?.errorCode == "ERROR_CODE_1"
            ) {
              setLoginState(initialState);
              clearAuthResponseError();
              // Error handle logic
            } else {
              setLoginState(initialState);
            }
          },
        },
      ]);
    }
  }, [state.authResponseError]);
  ```

